### PR TITLE
Add error handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,5 +6,8 @@ process.env['PATH'] = process.env['PATH'] + ':' + process.env['LAMBDA_TASK_ROOT'
 exports.handler = function(event, context) {
 	var memStream = new MemoryStream();
 	var html_utf8 = new Buffer(event.html_base64, 'base64').toString('utf8');
-	wkhtmltopdf(html_utf8, event.options, function(code, signal) { context.done(null, { pdf_base64: memStream.read().toString('base64') }); }).pipe(memStream);	
+	
+	wkhtmltopdf(html_utf8, event.options, function(err, stream) {
+		callback(err, {pdf_base64: memStream.read().toString('base64')});
+  	}).pipe(memStream);
 };


### PR DESCRIPTION
Note as per AWS docs: The callback is supported only in the Node.js runtime v4.3

http://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-handler.html